### PR TITLE
Replace polyfill.io with fastly alternative

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="preconnect" href="https://www.ft.com" />
-    <link rel="preconnect" href="https://cdn.polyfill.io" />
+    <link rel="preconnect" href="https://polyfill-fastly.io" />
 
     <% (htmlWebpackPlugin.options.context.stylesheets || []).forEach(stylesheet => { %>
     <link rel="stylesheet" href="<%= stylesheet %>" />
@@ -67,7 +67,7 @@
       <%= JSON.stringify({ sentryEndpoint: 'https://ddbd80489ff549538250bbe37fa52bbd@sentry.io/71130'}) %>
     </script>
     <% } %>
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=<%= htmlWebpackPlugin.options.context.polyfillFeatures %>"></script>
+    <script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=<%= context.polyfillFeatures %>"></script>
 
     <script type="text/javascript">
       cutsTheMustard =


### PR DESCRIPTION
Due to ownership of polyfill.io to an untrusted third party, we're moving to a new Fastly hosted version.